### PR TITLE
FIX: cannot import name ScriptBase

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,7 +2,7 @@
 parts = kbdcounter
 
 [kbdcounter]
-recipe = z3c.recipe.scripts
+recipe = zc.recipe.egg
 eggs = python-xlib
 extra-paths = ${buildout:directory}/src
 entry-points = kbdcounter=kbdcounter:run


### PR DESCRIPTION
Original fix https://github.com/forsberg/kbdcounter/issues/2